### PR TITLE
Use secure URI in Vcs-Git control header.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+autorenamer (0.4-2) UNRELEASED; urgency=medium
+
+  * Use secure URI in Vcs-Git control header.
+
+ -- Jelmer Vernooĳ <jelmer@debian.org>  Tue, 11 Sep 2018 22:42:58 +0100
+
 autorenamer (0.4-1) unstable; urgency=medium
 
   * New upstream version:

--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Marcin Owsiany <porridge@debian.org>
 Build-Depends: debhelper (>= 8), python, dh-python
 Standards-Version: 3.9.6
 Vcs-Browser: https://github.com/porridge/autorenamer
-Vcs-Git: git://github.com/porridge/autorenamer.git -b debian
+Vcs-Git: https://github.com/porridge/autorenamer.git -b debian
 Homepage: http://marcin.owsiany.pl/autorenamer-page
 
 Package: autorenamer


### PR DESCRIPTION
Use secure URI in Vcs-Git control header.

Fixes lintian: vcs-field-uses-insecure-uri
See https://lintian.debian.org/tags/vcs-field-uses-insecure-uri.html for more details.
